### PR TITLE
Added SSL support

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,16 @@
     GET /_/page/cells/A1
         Returns a JSON representation of a single cell in the page.
 
+                               -[ Using SSL ]-
+
+    $ openssl genrsa -out ethercalc-key.pem 1024 
+    $ openssl req -new -key ethercalc-key.pem -out certrequest.csr
+    $ openssl x509 -req -in certrequest.csr -signkey ethercalc-key.pem -out ethercalc-cert.pem
+
+    bin/ethercalc --keyfile ethercalc-key.pem --certfile ethercalc-cert.pem --basepath https://localhost:8000
+
+    Supply basepath because express's @redirect falls back to http.
+
                                -[ Licensing ]-
 
     Common Public Attribution License (Socialtext Inc.):
@@ -50,3 +60,4 @@
     CC0 Public Domain (唐鳳):
 
         src/*.ls
+

--- a/app.js
+++ b/app.js
@@ -24,8 +24,15 @@ This work is published from Taiwan.
   host = (argv != null ? argv.host : void 8) || process.env.VCAP_APP_HOST || '0.0.0.0';
   key = (argv != null ? argv.key : void 8) || null;
   basepath = replace$.call((argv != null ? argv.basepath : void 8) || "", /\/$/, '');
-  console.log("Please connect to: http://" + (host === '0.0.0.0' ? require('os').hostname() : host) + ":" + port + "/");
-  require('zappajs')(port, host, function(){
+  
+  keyfile = (argv != null ? argv.keyfile : void 8) || null;
+  certfile = (argv != null ? argv.certfile : void 8) || null;
+  ssl = (keyfile != null && certfile !=null);
+  options =  ssl ? {https: { key: require('fs').readFileSync(keyfile,'utf8'), 
+                             cert:require('fs').readFileSync(certfile,'utf8')}} : null;
+  transport = (ssl ? "https" : "http");
+  console.log("Please connect to: " + transport + "://" + (host === '0.0.0.0' ? require('os').hostname() : host) + ":" + port + "/");
+  require('zappajs')(port, host, options, function(){
     this.KEY = key;
     this.BASEPATH = basepath;
     return this.include('main');


### PR DESCRIPTION
Hi Audrey,

I've added SSL support to EtherCalc.

This was particularly simple as only
- command line parameters need to be parsed and
- appropriate values have to be passed to zappajs.

EtherCalc can now be invoked like:

```
  bin/ethercalc --keyfile ethercalc-key.pem --certfile ethercalc-cert.pem --basepath https://localhost:8000
```

Currently you have to supply basepath because the _@redirect_ of the express version used by zappajs falls back from https to http.

Documentation in README is also updated accordingly.

Regards,
    Ulrich
