### PR TITLE
Handle hyphenated CSS Properties

### DIFF
--- a/sc.js
+++ b/sc.js
@@ -387,7 +387,7 @@
                       var ref$, results$ = [];
                       for (k in ref$ = style) {
                         v = ref$[k];
-                        results$.push(k + ":" + v);
+                        results$.push(k.replace(/[A-Z]/g, '-$&').toLowerCase() + ":" + v);
                       }
                       return results$;
                     }()).join(";");

--- a/src/sc.ls
+++ b/src/sc.ls
@@ -170,7 +170,7 @@ catch => console.log "Falling back to vm.CreateContext backend"; class => (code)
             -> @raw or [e.outerHTML for e in @elems].join("\n")
           outerHTML:  ~->
             {tag, attrs, style} = @
-            css = style.cssText or [ "#k:#v" for k, v of style ].join(";")
+            css = style.cssText or [ "#{k.replace(/[A-Z]/g, '-$&').toLowerCase()}:#v" for k, v of style ].join(";")
             if css then attrs.style = css else delete attrs.style
             return "<#tag#{
               [ " #k=\"#v\"" for k, v of attrs ].join('')


### PR DESCRIPTION
camelCase properties of style like borderCollapse need to be converted to hyphenated, like border-collapse

I haven't found a resource saying that this is universally true, but testing seems to confirm it and it looks correct based on http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-extended

The specific issue I was looking to address is the style of the <table> element on the HTML export - it has a style attribute which contains "borderCollapse:collapse;" but it should be "border-collapse:collapse;"
