### PR TITLE
Docker image improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-# docker run -d -p 6967:6967 -v /var/lib/docker/binds/ethercalc-redis:/redis:rw audreyt/ethercalc
 #
-FROM dockerfile/nodejs
+# This image requires a linked redis Docker container:
+#
+#    docker run -d redis
+#    docker run -d -p 8000:8000 --link redis:redis audreyt/ethercalc
+#
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV PORT 6967
-VOLUME ["/redis"]
+FROM node:0.10-slim
 
-RUN echo "deb http://ppa.launchpad.net/chris-lea/redis-server/ubuntu precise main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -y build-essential python
-RUN apt-get install --force-yes -y build-essential python redis-server
-RUN export HOME=/tmp ; npm i -g ethercalc pm2
+RUN useradd ethercalc --create-home
+RUN npm install -g ethercalc pm2
 
-CMD ["sh", "-c", "sysctl vm.overcommit_memory=1 ; cd /redis ; /usr/bin/redis-server --logfile redis.log --dbfilename dump.rdb | (sleep 2 && pm2 start -x /usr/bin/ethercalc -- --cors)"]
+USER ethercalc
+EXPOSE 8000
+CMD ["sh", "-c", "REDIS_HOST=$REDIS_PORT_6379_TCP_ADDR REDIS_PORT=$REDIS_PORT_6379_TCP_PORT pm2 start -x /usr/local/bin/ethercalc -- --cors && pm2 logs"]

--- a/README.mkdn
+++ b/README.mkdn
@@ -27,16 +27,16 @@ For local non-root installation
     make
 
 Or install with our [Docker](http://www.docker.io/) image, which comes with a
-built-in Redis server and webworker-threads support:
+webworker-threads support:
 
-    # Runs at port 6967
-    sudo docker run -d -p 6967:6967 -v /var/lib/redis:/redis:rw audreyt/ethercalc
+    # Run a redis Docker using the official redis Docker image with persistant database in <host-directory>
+    sudo docker run --name redis -d -v <host-directory>:/data redis:latest
 
-    # Runs at another port, for example 8080
-    sudo docker run -d -p 8080:6967 -v /var/lib/redis:/redis:rw audreyt/ethercalc
+    # Run ethercalc on default port 8000
+    sudo docker run -d -p 8000:8000 --link redis:redis audreyt/ethercalc
 
-Note the use of `-v` flag to store the Redis database in `/var/lib/redis` on
-the host server. In Docker versions 0.4.x, the flag was called `-b` instead.
+    # Run ethercalc on custom port 8000
+    sudo docker run -d -p 80:8000 --link redis:redis audreyt/ethercalc
 
 ## REST API
 


### PR DESCRIPTION
- Use official node and redis images
- One single service per Docker container
- Run ethercalc with non-root user
- Print pm2 logs to stdout

Signed-off-by: Vincent Giersch vincent.giersch@ovh.net
