### PR TITLE
Add HOME variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN useradd ethercalc --create-home
 RUN npm install -g ethercalc pm2
 
 USER ethercalc
+ENV HOME /home/ethercalc
 EXPOSE 8000
 CMD ["sh", "-c", "REDIS_HOST=$REDIS_PORT_6379_TCP_ADDR REDIS_PORT=$REDIS_PORT_6379_TCP_PORT pm2 start -x /usr/local/bin/ethercalc -- --cors && pm2 logs"]


### PR DESCRIPTION
Prevents $HOME for ethercalc user being set to /, leading to the following error:

```
fs.js:653
  return binding.mkdir(pathModule._makeLong(path),
                 ^
Error: EACCES, permission denied '/.pm2'
    at Object.fs.mkdirSync (fs.js:653:18)
    at Object.CLI.pm2Init (/usr/local/lib/node_modules/pm2/lib/CLI.js:33:8)
    at Object.<anonymous> (/usr/local/lib/node_modules/pm2/bin/pm2:19:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
