### PR TITLE
Update socialcalctableeditor.js

### DIFF
--- a/socialcalctableeditor.js
+++ b/socialcalctableeditor.js
@@ -1832,7 +1832,6 @@ SocialCalc.EditorOpenCellEdit = function(editor) {
    if (editor.inputBox.element.disabled) return true; // multi-line: ignore
    editor.inputBox.ShowInputBox(true);
    editor.inputBox.Focus();
-   editor.state = "inputboxdirect";
    editor.inputBox.SetText("");
    editor.inputBox.DisplayCellContents();
    editor.inputBox.Select("end");


### PR DESCRIPTION
If enters cell editing via F2 or DBClick, state "inputboxdirect"  will cause the formula range selection to fail