### PR TITLE
Fix undo delete multiple rows/columns command bug.

### DIFF
--- a/socialcalc-3.js
+++ b/socialcalc-3.js
@@ -2701,12 +2701,12 @@ SocialCalc.ExecuteSheetCommand = function(sheet, cmd, saveundo) {
          if (saveundo) {
             if (cmd1 == "deletecol") {
                for (col=cr1.col; col<=cr2.col; col++) {
-                  changes.AddUndo("insertcol "+SocialCalc.rcColname(col));
+                  changes.AddUndo("insertcol "+SocialCalc.rcColname(cr1.col));
                   }
                }
             else {
                for (row=cr1.row; row<=cr2.row; row++) {
-                  changes.AddUndo("insertrow "+row);
+                  changes.AddUndo("insertrow "+cr1.row);
                   }
                }
             }


### PR DESCRIPTION
Fix undo delete multi rows/columns command overwrite exist row/column data and generate blank row/column bug.

When user delete multiple rows or column in a command (ex: deleterow A3:E4 ), then execute undo command, it will show situation below:
 - Original 3rd and 4th rows are back, but original 5th row data disappear.

This situation is caused by pushing wrong commands into undo stack. (insert row/column to wrong place.)