### PR TITLE
Prevent sheet URLs being leaked via referrer headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+<meta name="referrer" content="no-referrer"/>
 <title>EtherCalc - Share the URL to your friends and edit together!</title>
 <script>
 if (!(window.location.hash.replace('#', ''))) {


### PR DESCRIPTION
This change is to prevent browsers sending referrer headers from EtherCalc.

It fixes the scenario where a user clicks a link within a spreadsheet and their browser sends along the EtherCalc sheet URL in the Referrer header (allowing that site to view and edit the spreadsheet).

The meta tag is part of the [Referrer Policy spec](https://w3c.github.io/webappsec/specs/referrer-policy/) and already works in Chrome and Firefox.

Thanks for your work maintaining EtherCalc!