### PR TITLE
Allow to specify DB number in archive.ls

### DIFF
--- a/misc/archive.ls
+++ b/misc/archive.ls
@@ -1,6 +1,10 @@
 #!/usr/local/bin/lsc
 require! <[ fs redis ]>
 r = redis.createClient!
+env = process.env
+redisDb = env<[ REDIS_DB ]>
+if redisDb
+  r.select redisDb
 _, ks <- r.keys "snapshot-*"
 step = ->
   process.exit! unless ks.length


### PR DESCRIPTION
While we now can choose the DB number for ethercalc, archive.ls still use the default DB (0).

This allow to choose the DB number. 