### PR TITLE
add a hint for needed apache modules on apache2.4

### DIFF
--- a/apache/apache-proxy.conf
+++ b/apache/apache-proxy.conf
@@ -6,6 +6,13 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
+	#
+    # Hint for Apache 2.4
+    # You need to enable:
+    # - mod_proxy
+    # -	mod_proxy_http
+    # - mod_proxy_wstunnel
+    # else you get a working ethercalc instance with datashifts in it!
 	ServerName myethercalc.domain.com
 
 	ServerAdmin webmaster@localhost


### PR DESCRIPTION
If you use Apache2.4 you need to enable several proxy modules. 

If you forget mod_proxy_wstunnel you get a working ethercalc instance, but the data in it will shift in rows and columns.

So I added this hint to the apache-proxy.conf