### PR TITLE
Fix for issue #411

### DIFF
--- a/main.js
+++ b/main.js
@@ -603,7 +603,7 @@
           return SC._get(room, IO, function(arg$){
             var log, snapshot, row, cmdstr;
             log = arg$.log, snapshot = arg$.snapshot;
-            if (/^loadclipboard\s*/.exec(command)) {
+            if (!this$.request.is('application/json') && /^loadclipboard\s*/.exec(command)) {
               row = 1;
               if (/\nsheet:c:\d+:r:(\d+):/.exec(snapshot)) {
                 row += Number(RegExp.$1);

--- a/src/main.ls
+++ b/src/main.ls
@@ -367,7 +367,7 @@
       @response.type Text
       return @response.send 400 'Please send command'
     {log, snapshot} <~ SC._get room, IO
-    if command is /^loadclipboard\s*/
+    if not (@request.is \application/json) and command is /^loadclipboard\s*/
       row = 1
       if snapshot is /\nsheet:c:\d+:r:(\d+):/
         row += Number(RegExp.$1)


### PR DESCRIPTION
Adds an extra condition where if the request content is JSON then commands are processed as provided. Previously, the special `loadclipboard` handling (when other formats are converted and [posted internally as a `loadclipboard` command](https://github.com/audreyt/ethercalc/blob/0fea2ac4efc3db4d27730ef6ee95a98856b8fce6/src/main.ls#L303) too) was hijacking the request. See #411 for more.

Hope this is a reasonable fix otherwise happy to revise.
