### PR TITLE
add snapcraft.yaml file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ethercalc
+version: 0.20151108.1+
+summary: EtherCalc is a web spreadsheet.
+description: |
+   Your data is saved on the web, and people can edit the same document at
+   the same time. Everybody's changes are instantly reflected on all screens.
+   .
+   Work together on inventories, survey forms, list management, brainstorming
+   sessions and more! 
+confinement: strict
+grade: devel # use "stable" to assert the snap quality
+
+apps:
+  ethercald:
+    daemon: simple
+    command: bin/ethercalc
+    plugs: [network, network-bind]
+
+
+parts:
+  ethercalc:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
In the last days I created a snap of `ethercalc` and this PR contains the `snapcraft.yaml` that's required to build it. I tested it to some degree, but to make sure it's working well enough to be published and distributed to users I need your help.

I'd love to hear if you are generally interested in your software being available as a snap and if you could imagine shipping the `snapcraft.yaml` file in your source repository for easier publishing.

### Background info
If you haven't heard of snaps yet, they are self-contained apps, which can be used on a [multitude of Linux systems](https://snapcraft.io). Via `seccomp`, `apparmor` and other Linux security features, they provide great security for users, uploads to the store are available within seconds and you have
full control over your relevant stack.

Snaps can be installed by millions of users: Ubuntu 16.04 LTS and later have `snapd` installed by default and many other Linux distributions, like Arch, Debian, Gentoo, Fedora, openSUSE, OpenEmbedded, Yocto and OpenWRT made `snapd` (which powers the snap experience) available as well.

### Publishing
Uploading to the store can be done via the command line and there are multiple release channels available, so users can choose between for example stable, beta and alpha releases. You could even hook up `snapcraft upload` with Travis to auto-publish release tags or nightly builds. The process for this is very simple:

 - Once:
  - Register an account at http://myapps.developer.ubuntu.com/
  - Run `snapcraft login`
  - Run `snapcraft register ethercalc`
 - `snapcraft push ethercalc_<version>.snap --release=beta`
