### PR TITLE
[MultiSheet] Show scroll bar on sheets navbar when needed

### DIFF
--- a/multi/styles.styl
+++ b/multi/styles.styl
@@ -76,5 +76,12 @@ iframe
 .wrapper
   position absolute
   width 100%
-  bottom 30px
+  bottom 51px
   top 0
+
+body > .nav > .buttons,
+body > .nav > .basic-tabs > nav.basic-tabs.basic-tabs-strip
+  height 43px
+
+body > .nav > .basic-tabs > nav.basic-tabs.basic-tabs-strip
+  overflow-x auto


### PR DESCRIPTION
When you have a lot of sheets, or a small screen, you can't easily
navigate between sheets since the first or the last sheet buttons are
hidden.

This adds overflow-x auto, and increases the height of the sheet navbar
to nicely display the scrollbar when needed.