### PR TITLE
Make it possible to connect to the redis server over a unix socket vi…

### DIFF
--- a/db.js
+++ b/db.js
@@ -3,12 +3,12 @@
   var slice$ = [].slice;
   this.__DB__ = null;
   this.include = function(){
-    var env, ref$, redisPort, redisHost, redisPass, redisDb, dataDir, services, name, items, ref1$, redis, makeClient, RedisStore, db, EXPIRE, this$ = this;
+    var env, ref$, redisPort, redisHost, redisSockpath, redisPass, redisDb, dataDir, services, name, items, ref1$, redis, makeClient, RedisStore, db, EXPIRE, this$ = this;
     if (this.__DB__) {
       return this.__DB__;
     }
     env = process.env;
-    ref$ = [env['REDIS_PORT'], env['REDIS_HOST'], env['REDIS_PASS'], env['REDIS_DB'], env['OPENSHIFT_DATA_DIR']], redisPort = ref$[0], redisHost = ref$[1], redisPass = ref$[2], redisDb = ref$[3], dataDir = ref$[4];
+    ref$ = [env['REDIS_PORT'], env['REDIS_HOST'], env['REDIS_SOCKPATH'], env['REDIS_PASS'], env['REDIS_DB'], env['OPENSHIFT_DATA_DIR']], redisPort = ref$[0], redisHost = ref$[1], redisSockpath = ref$[2], redisPass = ref$[3], redisDb = ref$[4], dataDir = ref$[5];
     services = JSON.parse(process.env.VCAP_SERVICES || '{}');
     for (name in services) {
       items = services[name];
@@ -22,7 +22,11 @@
     redis = require('redis');
     makeClient = function(cb){
       var client;
-      client = redis.createClient(redisPort, redisHost);
+      if (redisSockpath) {
+        client = redis.createClient(redisSockpath);
+      } else {
+        client = redis.createClient(redisPort, redisHost);
+      }
       if (redisPass) {
         client.auth(redisPass, function(){
           return console.log.apply(console, arguments);
@@ -63,7 +67,11 @@
     } catch (e$) {}
     db = makeClient(function(){
       db.DB = true;
-      return console.log("Connected to Redis Server: " + redisHost + ":" + redisPort);
+      if (redisSockpath) {
+        return console.log("Connected to Redis Server: unix:" + redisSockpath);
+      } else {
+        return console.log("Connected to Redis Server: " + redisHost + ":" + redisPort);
+      }
     });
     EXPIRE = this.EXPIRE;
     db.on('error', function(err){

--- a/src/db.ls
+++ b/src/db.ls
@@ -3,7 +3,7 @@
   return @__DB__ if @__DB__
 
   env = process.env
-  [redisPort, redisHost, redisPass, redisDb, dataDir] = env<[ REDIS_PORT REDIS_HOST REDIS_PASS REDIS_DB OPENSHIFT_DATA_DIR ]>
+  [redisPort, redisHost, redisSockpath, redisPass, redisDb, dataDir] = env<[ REDIS_PORT REDIS_HOST REDIS_SOCKPATH REDIS_PASS REDIS_DB OPENSHIFT_DATA_DIR ]>
 
   services = JSON.parse do
     process.env.VCAP_SERVICES or '{}'
@@ -18,7 +18,10 @@
 
   require! \redis
   make-client = (cb) ->
-    client = redis.createClient redisPort, redisHost
+    if redisSockpath
+      client = redis.createClient redisSockpath
+    else
+      client = redis.createClient redisPort, redisHost
     if redisPass
       client.auth redisPass, -> console.log ...arguments
     if redisDb
@@ -42,7 +45,11 @@
 
   db = make-client ~>
     db.DB = true
-    console.log "Connected to Redis Server: #redisHost:#redisPort"
+    if redisSockpath
+      client = redis.createClient redisSockpath
+      console.log "Connected to Redis Server: unix:#redisSockpath"
+    else
+      console.log "Connected to Redis Server: #redisHost:#redisPort"
 
   EXPIRE = @EXPIRE
   db.on \error (err) ->

--- a/src/db.ls
+++ b/src/db.ls
@@ -46,7 +46,6 @@
   db = make-client ~>
     db.DB = true
     if redisSockpath
-      client = redis.createClient redisSockpath
       console.log "Connected to Redis Server: unix:#redisSockpath"
     else
       console.log "Connected to Redis Server: #redisHost:#redisPort"


### PR DESCRIPTION
…a REDIS_SOCKPATH in the env.


I'm using ethercalc on OpenBSD and my redis server is configured to listen on a unix socket (note that it's also a recommendation from https://github.com/NodeRedis/node_redis#rediscreateclient) - using this db.js patch allows ethercalc to connect to redis via this socket. If the user running ethercalc doesnt have write rights to the socket, you get a EACCES, but that's expected.
```
$id _node
uid=1001(_node) gid=1001(_node) groups=1001(_node)

[Error: Redis connection to /var/run/redis/redis.sock failed - connect EACCES]
==> Falling back to JSON storage: //dump.json

$ls -l /var/run/redis/redis.sock
srwxrwx---  1 _redis  _redis  0 Jul  1  2015 /var/run/redis/redis.sock

$id _node 
uid=1001(_node) gid=1001(_node) groups=1001(_node), 686(_redis)

Connected to Redis Server: unix:/var/run/redis/redis.sock
```

I've *never* touched livescript before, so the db.ls chunk is totally blindly done, as i dont have a livescript compiler around on OpenBSD (not ported (yet?)). Of course, it can probably be written nicer, would love feedback on the idea first. the db.js part works and is tested :)