### PR TITLE
/_roomtimes shows last update timestamps

### DIFF
--- a/src/main.ls
+++ b/src/main.ls
@@ -234,6 +234,15 @@
           "<a href=#BASEPATH/#room>#room</a>"
         @response.type Html
         @response.json 200 roomlinks
+  if @CORS
+     @get '/_roomtimes' : ->
+        @response.type Text
+        return @response.send 403 '_roomtimes not available with CORS'
+  else
+     @get '/_roomtimes' : ->
+        roomtimes <~ SC._roomtimes
+        @response.type \application/json
+        @response.json 200 roomtimes
 
   @get '/_from/:template': ->
     room = new-room!

--- a/src/main.ls
+++ b/src/main.ls
@@ -240,9 +240,16 @@
         return @response.send 403 '_roomtimes not available with CORS'
   else
      @get '/_roomtimes' : ->
+        # Get roomtimes
         roomtimes <~ SC._roomtimes
+        # Sort roomtimes
+        rooms = [r for r, time of roomtimes]
+        sorted_rooms = rooms.sort (a, b) -> roomtimes[b] - roomtimes[a]
+        sorted_times = {}
+        for r in sorted_rooms
+           sorted_times[r] = roomtimes[r]
         @response.type \application/json
-        @response.json 200 roomtimes
+        @response.json 200 sorted_times
 
   @get '/_from/:template': ->
     room = new-room!

--- a/src/sc.ls
+++ b/src/sc.ls
@@ -114,6 +114,9 @@ Worker ||= class => (code) ->
        .keys \snapshot-*
        .exec!
     cb [ ..replace(/^snapshot-/, "") for rooms]
+  SC._roomtimes = (cb) ->
+    (_, res) <~ DB.hgetall "timestamps"
+    cb res
   SC._exists = (room, cb) ->
     (, [x]) <~ DB.multi!
        .exists "snapshot-#room"
@@ -199,6 +202,7 @@ Worker ||= class => (code) ->
       w._snapshot = newSnapshot
       <~ DB.multi!
         .set "snapshot-#room" newSnapshot
+        .hset \timestamps "timestamp-#room" Date.now()
         .del "log-#room"
         .bgsave!
         .exec!


### PR DESCRIPTION
  * Updating a sheet saves a UTC timestamp to the database
  * Uses hset with hash "timestamps", with key-value timestamp-{room} : UTC
  * Accessing host/_roomtimes outputs json dump of timestamps for each room
  * Implements feature request discussed in audreyt/ethercalc#124
  * roomtimes are sorted by UTC (latest first)