### PR TITLE
Fix container error that deployed by docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ ethercalc:
   image: audreyt/ethercalc
   ports:
     - "80:8000"
+  environment:
+    REDIS_PORT_6379_TCP_ADDR: redis
+    REDIS_PORT_6379_TCP_PORT: 6379
   links:
     - redis:redis
   restart: always


### PR DESCRIPTION
Use docker-compose.yml to deploy ethercalc would cause an error
redis can not connet. This patch can fix this error.