### PR TITLE
Dump json storage as multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
-/dump.json
+/dump/
 *.swp

--- a/src/db.ls
+++ b/src/db.ls
@@ -67,28 +67,61 @@
     db.DB = {}
     minimatch = require \minimatch
     try
-      db.DB = {}
-      fs.readdirSync "#dataDir/dump/" .forEach (f) ->
-        Object.assign do
-          db.DB,
-          JSON.parse fs.readFileSync "#dataDir/dump/#f"
-      console.log "==> Restored previous session from JSON files"
+      if fs.existsSync "#dataDir/dump/"
+        fs.readdirSync("#dataDir/dump/").forEach (f) ->
+          key = f.split(".")[0]
+          type = key.split("-")[0]
+          if type is "timestamps"
+            db.DB.timestamps = JSON.parse(fs.readFileSync("#dataDir/dump/timestamps.json", \utf8))
+          else if type is "snapshot"
+            db.DB[key] = fs.readFileSync("#dataDir/dump/#key.txt", \utf8)
+          else if type is "audit"
+            db.DB[key] = fs.readFileSync("#dataDir/dump/#key.txt", \utf8).split("\n")
+            for k, v of db.DB[key]
+              db.DB[key][k] = db.DB[key][k].replace(/\\n/g,"\n").replace(/\\r/g,"\r").replace(/\\\\/g,"\\")
+      else
+        db.DB = JSON.parse(fs.readFileSync "#dataDir/dump.json" \utf8)
+
+      console.log "==> Restored previous session from dump storage"
       db.DB = {} if db.DB is true
     Commands =
       bgsave: (cb) ->
         if !fs.existsSync "#dataDir/dump/"
-          fs.mkdirSync("#dataDir/dump/")
-        sheets = {}
+          fs.mkdirSync "#dataDir/dump/"
+
+        oldTimestamps = {}
+        if !fs.existsSync "#dataDir/dump/timestamps.json"
+          for k, v of db.DB.timestamps
+            id = k.split("-").pop!
+            oldTimestamps[id] = 0 #if no timestamp file is found, pretend the sheets haven't been saved in litteral decades
+        else
+          for k, v of (JSON.parse fs.readFileSync "#dataDir/dump/timestamps.json" \utf8)
+            id = k.split("-").pop!
+            oldTimestamps[id] = v
+
+        newTimestamps = {}
+        for k, v of db.DB.timestamps
+          id = k.split("-").pop!
+          newTimestamps[id] = v
+
         for k, v of db.DB
-          id = k.split("-").pop!.split("_")[0]
-          if !sheets[id]
-            sheets[id] = {}
-          sheets[id][k] = v
-        for k, v of sheets
-          fs.writeFileSync do
-            "#dataDir/dump/#k.json"
-            JSON.stringify sheets[k],,2
-            \utf8
+          id = k.split("-").pop!
+          unless oldTimestamps[id] is newTimestamps[id]
+            type = k.split("-")[0]
+            switch type
+            case "snapshot"
+              fs.writeFileSync("#dataDir/dump/#k.txt",v,\utf8)
+            case "audit"
+              str = ""
+              for entry in v
+                str += entry.replace(/[\n]/g,"\\n").replace(/[\r]/g,"\\r").replace(/\\/g,"\\\\") + "\n"
+              fs.writeFileSync("#dataDir/dump/#k.txt",str,\utf8)
+
+        fs.writeFileSync do
+          "#dataDir/dump/timestamps.json"
+          JSON.stringify db.DB.timestamps,,2
+          \utf8
+
         cb?!
       get: (key, cb) -> cb?(null, db.DB[key])
       set: (key, val, cb) -> db.DB[key] = val; cb?!


### PR DESCRIPTION
I changed db.ls so that when Redis is not available, the database is
stored as a folder of json files, instead of a single file. It will
group attributes corresponding to the same sheet in a single file named
after the id of the sheet.