### PR TITLE
Fix fallback storage log message

### DIFF
--- a/db.js
+++ b/db.js
@@ -85,7 +85,7 @@
 
       }
       console.log(err);
-      console.log("==> Falling back to JSON storage: " + dataDir + "/dump/");
+      console.log("==> Falling back to file system storage: " + dataDir + "/dump/");
       if (EXPIRE) {
         console.log("==> The --expire <seconds> option requires a Redis server; stopping!");
         process.exit();

--- a/src/db.ls
+++ b/src/db.ls
@@ -58,7 +58,7 @@
     | db.DB => return false
     | otherwise
     console.log err
-    console.log "==> Falling back to JSON storage: #{ dataDir }/dump/"
+    console.log "==> Falling back to file system storage: #{ dataDir }/dump/"
     if EXPIRE
       console.log "==> The --expire <seconds> option requires a Redis server; stopping!"
       process.exit!


### PR DESCRIPTION
The fallback storage is not based on JSON anymore but as a collection of files in a directory and in most natural formats.

This PR address [a review comment](https://github.com/audreyt/ethercalc/pull/597#discussion_r174103259) from #597.