### PR TITLE
security(worker): harden hosted export + email surface

### DIFF
--- a/packages/worker/src/lib/csv-encode.ts
+++ b/packages/worker/src/lib/csv-encode.ts
@@ -16,6 +16,7 @@
  * Round-trip invariant (enforced in the .node.test.ts):
  *   parseCSV(encodeCSV(rows)) === rows  (for rows of strings)
  */
+import { parseCSV } from './csv-parse.ts';
 
 /**
  * Return `field` quoted if any of `,`, `"`, `\r`, or `\n` appear; otherwise
@@ -26,6 +27,38 @@ export function encodeCSVField(field: string): string {
     return `"${field.replace(/"/g, '""')}"`;
   }
   return field;
+}
+
+// A field is treated as a potential spreadsheet formula if it begins with one
+// of these characters (OWASP CSV-injection guidance). Tab/CR are included
+// because Excel/Sheets trim leading whitespace before evaluating the cell.
+const CSV_INJECTION_LEAD = /^[=+\-@\t\r]/;
+// Genuinely numeric values (incl. signed and scientific) are NOT formulas —
+// neutralizing `-5` or `+3.14` would corrupt ordinary data, so they're exempt.
+const CSV_NUMERIC = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/**
+ * Defang a single CSV field against formula/DDE injection. When a field
+ * starts with a formula-trigger character and is not a plain number, prefix
+ * it with a single quote so spreadsheet apps render it as literal text
+ * instead of evaluating `=HYPERLINK(...)`, `=cmd|'/c calc'!A1`, etc. on
+ * download. Everything else is returned unchanged.
+ */
+export function neutralizeCSVFormula(field: string): string {
+  if (CSV_INJECTION_LEAD.test(field) && !CSV_NUMERIC.test(field)) {
+    return `'${field}`;
+  }
+  return field;
+}
+
+/**
+ * Re-emit a CSV document with every field defanged against formula
+ * injection. Parses the source (the strict subset SocialCalc emits),
+ * neutralizes each field, and re-encodes. Benign documents round-trip
+ * byte-for-byte; only formula-shaped cells gain a leading `'`.
+ */
+export function neutralizeCSVDocument(csv: string): string {
+  return encodeCSV(parseCSV(csv).map((row) => row.map(neutralizeCSVFormula)));
 }
 
 /**

--- a/packages/worker/src/lib/email.ts
+++ b/packages/worker/src/lib/email.ts
@@ -32,6 +32,22 @@ export interface SendemailParsed {
 }
 
 /**
+ * Strip characters that would let an attacker-controlled cell value break
+ * out of an RFC822 header line: CR, LF, and the NUL/control bytes that
+ * could fold a header or smuggle a second one (Cc/Bcc/Content-Type) or an
+ * arbitrary MIME body. The `to`/`subject` fields flow straight into header
+ * lines (`To: …`, `Subject: …`) and into the Cloudflare `send_email`
+ * binding's `to`, so both are sanitized at the boundary.
+ *
+ * Benign inputs (no control bytes) are returned unchanged, so this is a
+ * no-op for every real payload — it only neutralizes injection attempts.
+ */
+export function stripHeaderInjection(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\x00-\x1f\x7f]/g, '');
+}
+
+/**
  * Parse a raw SocialCalc command of the form
  *   sendemail <to> <subject> <body>
  *
@@ -55,8 +71,11 @@ export function parseSendemail(cmdstr: string): SendemailParsed | null {
   if (parts[0] !== 'sendemail') return null;
   const decode = (s: string): string => s.replace(/%20/g, ' ');
   return {
-    to: decode(parts[1]!),
-    subject: decode(parts[2]!),
+    // `to`/`subject` become RFC822 header lines downstream — strip any
+    // literal CR/LF/control bytes so an attacker-controlled cell can't
+    // inject extra headers (Cc/Bcc/Content-Type) or a second MIME part.
+    to: stripHeaderInjection(decode(parts[1]!)),
+    subject: stripHeaderInjection(decode(parts[2]!)),
     // Join trailing tokens back so a body that happened to contain a
     // literal space (encoded as %20) survives intact. Legacy only
     // indexed [3], but in practice the client always URL-encoded so a
@@ -166,11 +185,13 @@ export function buildMimeEnvelope(
   subject: string,
   body: string,
 ): string {
-  // RFC822 requires CRLF line endings. `\r\n` everywhere.
+  // RFC822 requires CRLF line endings. `\r\n` everywhere. Header values are
+  // re-sanitized here (defense-in-depth alongside `parseSendemail`) so this
+  // function can never emit a folded/injected header regardless of caller.
   const headers = [
-    `From: ${from}`,
-    `To: ${to}`,
-    `Subject: ${subject}`,
+    `From: ${stripHeaderInjection(from)}`,
+    `To: ${stripHeaderInjection(to)}`,
+    `Subject: ${stripHeaderInjection(subject)}`,
     'MIME-Version: 1.0',
     'Content-Type: text/plain; charset=utf-8',
   ];

--- a/packages/worker/src/lib/xlsx-import.ts
+++ b/packages/worker/src/lib/xlsx-import.ts
@@ -18,6 +18,47 @@
 import * as XLSX from '@e965/xlsx';
 import { loadSocialCalc } from '@ethercalc/socialcalc-headless';
 
+/**
+ * Upper bound on the number of populated cells we will replay from an
+ * imported workbook. Each cell drives a synchronous SocialCalc
+ * `Parse` + `ExecuteSheetCommand` (plus a final full-sheet recalc), so an
+ * unbounded count is a CPU/memory DoS primitive: a small, highly-compressed
+ * xlsx/ods can declare millions of cells. 200k comfortably covers any real
+ * spreadsheet while capping the replay work. Exported so callers/tests can
+ * reference the limit.
+ */
+export const MAX_IMPORT_CELLS = 200_000;
+
+/** Thrown by `xlsxToSave` when an import exceeds {@link MAX_IMPORT_CELLS}. */
+export class ImportTooLargeError extends Error {
+  readonly cellCount: number;
+  constructor(cellCount: number) {
+    super(`xlsx/ods import exceeds ${MAX_IMPORT_CELLS} cells (${cellCount})`);
+    this.name = 'ImportTooLargeError';
+    this.cellCount = cellCount;
+  }
+}
+
+/**
+ * Count the populated cells on a SheetJS worksheet (keys that aren't
+ * `!`-prefixed metadata like `!ref` / `!merges`). This is the number of
+ * synchronous SocialCalc commands the import replay will dispatch.
+ */
+export function countWorksheetCells(ws: Record<string, unknown>): number {
+  return Object.keys(ws).filter((a) => !a.startsWith('!')).length;
+}
+
+/**
+ * Throw {@link ImportTooLargeError} when an import would replay more than
+ * {@link MAX_IMPORT_CELLS} cells. Called before the per-cell replay loop so
+ * an oversized/zip-bombed workbook can't pin the worker isolate.
+ */
+export function enforceImportLimit(cellCount: number): void {
+  if (cellCount > MAX_IMPORT_CELLS) {
+    throw new ImportTooLargeError(cellCount);
+  }
+}
+
 interface SheetJSCell {
   readonly v?: unknown;
   readonly t?: string;
@@ -107,6 +148,11 @@ export function xlsxToSave(bytes: Uint8Array): string {
     s: { r: number; c: number };
     e: { r: number; c: number };
   }> = Array.isArray(ws['!merges']) ? ws['!merges'] : [];
+
+  // Bail before the expensive per-cell SocialCalc replay if the workbook
+  // declares an unreasonable number of cells (zip-bomb / oversized used
+  // range). Counting keys is O(cells) but cheap relative to the replay.
+  enforceImportLimit(countWorksheetCells(ws));
 
   for (const addr of Object.keys(ws)) {
     if (addr.startsWith('!')) continue;

--- a/packages/worker/src/room.ts
+++ b/packages/worker/src/room.ts
@@ -40,6 +40,7 @@ import {
 import { buildEmailSender } from './handlers/cron.ts';
 import { parseSeedPayload } from './handlers/migrate.ts';
 import { verifyAuth } from './lib/auth.ts';
+import { neutralizeCSVDocument } from './lib/csv-encode.ts';
 import { parseCSV } from './lib/csv-parse.ts';
 import { parseSendemail } from './lib/email.ts';
 import { csvToMarkdown } from './lib/md.ts';
@@ -397,7 +398,10 @@ export class RoomDO implements DurableObject {
 
   async #getCsv(): Promise<Response> {
     const ss = await this.#getSpreadsheet();
-    return textResponse(ss.exportCSV(), TEXT_CSV);
+    // The `.csv` download is opened in desktop spreadsheet apps, so defang
+    // formula/DDE injection (`=`, `+`, `-`, `@`) before emitting. csv.json
+    // stays faithful — it's consumed as JSON, not evaluated as a formula.
+    return textResponse(neutralizeCSVDocument(ss.exportCSV()), TEXT_CSV);
   }
 
   async #getCsvJson(): Promise<Response> {

--- a/packages/worker/src/routes/exports.ts
+++ b/packages/worker/src/routes/exports.ts
@@ -100,9 +100,29 @@ async function dispatchMultiSheetExport(
     headers: {
       'Content-Type': BINARY_CONTENT_TYPES[format],
       'Content-Disposition': attachmentHeader(room, format),
+      'X-Content-Type-Options': 'nosniff',
     },
   });
 }
+
+/**
+ * Content-Security-Policy for the HTML export. SocialCalc emits cells whose
+ * `valueformat===text-html` are NOT escaped (socialcalc.bundled.ts), so an
+ * attacker who can write a room (anonymous write is by design) could plant
+ * `<img src=x onerror=…>` / `<script>` that would run in the deployment
+ * origin when someone opens `/:room.html`. The exported document is a static
+ * `<table>` with inline styles, so we lock it down to exactly that:
+ *
+ *   - `default-src 'none'` blocks scripts, fetch, frames, objects, etc.
+ *     (this alone neutralizes `<script>` and inline `onerror` handlers).
+ *   - `style-src 'unsafe-inline'` keeps the table's inline cell styling.
+ *   - `img-src` is intentionally omitted (covered by `default-src 'none'`)
+ *     so injected `<img>` never loads its `onerror` payload.
+ *
+ * `frame-ancestors` is deliberately NOT set — the HTML export is a
+ * documented external-embed surface (§13 Q8), so we must stay iframe-able.
+ */
+const HTML_EXPORT_CSP = "default-src 'none'; style-src 'unsafe-inline'";
 
 /** Format registry for dispatcher. Keyed by URL suffix / slot. */
 interface ExportFormat {
@@ -114,6 +134,8 @@ interface ExportFormat {
   readonly binary: boolean;
   /** If set, emit `Content-Disposition: attachment; filename="<room>.<ext>"`. */
   readonly attachmentExt?: string;
+  /** If set, emit this `Content-Security-Policy` on the response. */
+  readonly csp?: string;
 }
 
 const FORMATS: Readonly<Record<string, ExportFormat>> = {
@@ -121,6 +143,7 @@ const FORMATS: Readonly<Record<string, ExportFormat>> = {
     doPath: '/_do/html',
     contentType: 'text/html; charset=utf-8',
     binary: false,
+    csp: HTML_EXPORT_CSP,
   },
   csv: {
     doPath: '/_do/csv',
@@ -174,7 +197,15 @@ async function dispatchExport(
   if (res.status === 404) {
     return new Response('', { status: 404, headers: { 'Content-Type': TEXT_CT } });
   }
-  const headers: Record<string, string> = { 'Content-Type': format.contentType };
+  const headers: Record<string, string> = {
+    'Content-Type': format.contentType,
+    // Stop browsers from MIME-sniffing an export (e.g. a `.csv` whose first
+    // bytes look like HTML) into an executable type.
+    'X-Content-Type-Options': 'nosniff',
+  };
+  if (format.csp) {
+    headers['Content-Security-Policy'] = format.csp;
+  }
   if (format.attachmentExt) {
     headers['Content-Disposition'] = attachmentHeader(room, format.attachmentExt);
   }

--- a/packages/worker/test/csv-encode.node.test.ts
+++ b/packages/worker/test/csv-encode.node.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { encodeCSV, encodeCSVField } from '../src/lib/csv-encode.ts';
+import {
+  encodeCSV,
+  encodeCSVField,
+  neutralizeCSVDocument,
+  neutralizeCSVFormula,
+} from '../src/lib/csv-encode.ts';
 import { parseCSV } from '../src/lib/csv-parse.ts';
 
 /**
@@ -61,5 +66,52 @@ describe('encodeCSV', () => {
       ['/r.4', 'with\nnewline'],
     ];
     expect(parseCSV(encodeCSV(rows))).toEqual(rows);
+  });
+});
+
+describe('neutralizeCSVFormula', () => {
+  it('prefixes formula-trigger leading characters with a quote', () => {
+    expect(neutralizeCSVFormula('=1+1')).toBe("'=1+1");
+    expect(neutralizeCSVFormula('+cmd')).toBe("'+cmd");
+    expect(neutralizeCSVFormula('@SUM(A1)')).toBe("'@SUM(A1)");
+    expect(neutralizeCSVFormula('=HYPERLINK("http://x","go")')).toBe(
+      '\'=HYPERLINK("http://x","go")',
+    );
+    expect(neutralizeCSVFormula('\t=evil')).toBe("'\t=evil");
+    expect(neutralizeCSVFormula('\r=evil')).toBe("'\r=evil");
+  });
+
+  it('leaves plain numbers (including signed/scientific) untouched', () => {
+    expect(neutralizeCSVFormula('-5')).toBe('-5');
+    expect(neutralizeCSVFormula('+3.14')).toBe('+3.14');
+    expect(neutralizeCSVFormula('-1e9')).toBe('-1e9');
+    expect(neutralizeCSVFormula('.5')).toBe('.5');
+    expect(neutralizeCSVFormula('42')).toBe('42');
+  });
+
+  it('leaves ordinary text untouched', () => {
+    expect(neutralizeCSVFormula('hello')).toBe('hello');
+    expect(neutralizeCSVFormula('')).toBe('');
+    expect(neutralizeCSVFormula('a=b')).toBe('a=b');
+  });
+});
+
+describe('neutralizeCSVDocument', () => {
+  it('round-trips benign documents byte-for-byte', () => {
+    expect(neutralizeCSVDocument('a,b\n1,2\n')).toBe('a,b\n1,2\n');
+    expect(neutralizeCSVDocument('')).toBe('');
+  });
+
+  it('defangs formula cells while preserving structure + numbers', () => {
+    expect(neutralizeCSVDocument('=1+1,-5\n@foo,bar\n')).toBe(
+      "'=1+1,-5\n'@foo,bar\n",
+    );
+  });
+
+  it('quotes a defanged field that also needs CSV quoting', () => {
+    // A single quoted field whose content is `=A,B`: leading `=` triggers
+    // neutralization, and the embedded comma then forces RFC-4180 quoting of
+    // the now-`'=`-prefixed value.
+    expect(neutralizeCSVDocument('"=A,B"\n')).toBe("\"'=A,B\"\n");
   });
 });

--- a/packages/worker/test/exports.test.ts
+++ b/packages/worker/test/exports.test.ts
@@ -118,6 +118,15 @@ describe('Phase 8 exports — GET /_/:room/<format>', () => {
     expect(body.toLowerCase()).toContain('<table');
   });
 
+  it('HTML export carries an XSS-neutralizing CSP + nosniff', async () => {
+    const res = await request('GET', `/_/${ROOM}/html`);
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    const csp = res.headers.get('content-security-policy');
+    expect(csp).toContain("default-src 'none'");
+    // Must stay embeddable — no frame-ancestors lockdown.
+    expect(csp).not.toContain('frame-ancestors');
+  });
+
   it('GET /:room.html alias works', async () => {
     const res = await request('GET', `/${ROOM}.html`);
     expect(res.status).toBe(200);

--- a/packages/worker/test/lib-email.node.test.ts
+++ b/packages/worker/test/lib-email.node.test.ts
@@ -6,6 +6,7 @@ import {
   StubEmailSender,
   buildMimeEnvelope,
   parseSendemail,
+  stripHeaderInjection,
   type SendEmailBinding,
 } from '../src/lib/email.ts';
 
@@ -64,6 +65,33 @@ describe('parseSendemail', () => {
     // Four tokens, non-'sendemail' verb — hits the verb check only.
     expect(parseSendemail('settimetrigger A1 1 2')).toBeNull();
   });
+
+  it('strips CR/LF/control bytes from to + subject (header injection)', () => {
+    // A cell carrying a literal newline tries to smuggle a Bcc header and a
+    // forged Content-Type. After sanitizing, to/subject collapse to a single
+    // header-safe line; body is left intact.
+    const parsed = parseSendemail(
+      'sendemail victim@x.com\r\nBcc:evil@x.com Subj\r\nContent-Type:text/html body',
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.to).toBe('victim@x.comBcc:evil@x.com');
+    expect(parsed!.subject).toBe('SubjContent-Type:text/html');
+    expect(parsed!.to).not.toMatch(/[\r\n]/);
+    expect(parsed!.subject).not.toMatch(/[\r\n]/);
+  });
+});
+
+describe('stripHeaderInjection', () => {
+  it('removes CR, LF, NUL and DEL but preserves spaces + printables', () => {
+    expect(stripHeaderInjection('a b@c.com')).toBe('a b@c.com');
+    expect(stripHeaderInjection('a\r\nb')).toBe('ab');
+    expect(stripHeaderInjection('a\x00b\x1fc\x7fd')).toBe('abcd');
+    expect(stripHeaderInjection('a\tb')).toBe('ab');
+  });
+
+  it('is a no-op for already-clean values', () => {
+    expect(stripHeaderInjection('Subject Line 123')).toBe('Subject Line 123');
+  });
 });
 
 describe('StubEmailSender', () => {
@@ -97,6 +125,24 @@ describe('buildMimeEnvelope', () => {
         'hello',
       ].join('\r\n'),
     );
+  });
+
+  it('cannot be made to emit an injected header line', () => {
+    const raw = buildMimeEnvelope(
+      'noreply@example.com',
+      'u@example.com\r\nBcc: evil@example.com',
+      'hi\r\nContent-Type: text/html',
+      'body',
+    );
+    // Exactly the five header lines + blank + body — no smuggled header.
+    const [headerBlock] = raw.split('\r\n\r\n');
+    expect(headerBlock!.split('\r\n')).toEqual([
+      'From: noreply@example.com',
+      'To: u@example.comBcc: evil@example.com',
+      'Subject: hiContent-Type: text/html',
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+    ]);
   });
 });
 

--- a/packages/worker/test/xlsx-import.node.test.ts
+++ b/packages/worker/test/xlsx-import.node.test.ts
@@ -3,7 +3,14 @@ import { describe, it, expect } from 'vitest';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as XLSX from '@e965/xlsx';
 
-import { cellToCommand, xlsxToSave } from '../src/lib/xlsx-import.ts';
+import {
+  ImportTooLargeError,
+  MAX_IMPORT_CELLS,
+  cellToCommand,
+  countWorksheetCells,
+  enforceImportLimit,
+  xlsxToSave,
+} from '../src/lib/xlsx-import.ts';
 
 describe('cellToCommand', () => {
   it('formula cells emit `set <coord> formula <f>`', () => {
@@ -193,6 +200,23 @@ describe('xlsxToSave — roundtrip', () => {
     // xlsxToSave returns an empty SocialCalc save in that case.
     const save = xlsxToSave(new Uint8Array(0));
     expect(save).toContain('socialcalc:version');
+  });
+
+  it('rejects a workbook that exceeds the cell limit (zip-bomb guard)', () => {
+    // Build a fake worksheet with one more cell than the cap. We don't round-
+    // trip real bytes — counting the populated keys is exactly what the guard
+    // does — so the test stays fast while still pinning the limit.
+    const ws: Record<string, unknown> = { '!ref': 'A1:A1', '!merges': [] };
+    for (let i = 0; i < MAX_IMPORT_CELLS + 1; i++) ws[`c${i}`] = { t: 'n', v: i };
+    expect(countWorksheetCells(ws)).toBe(MAX_IMPORT_CELLS + 1);
+    expect(() => enforceImportLimit(countWorksheetCells(ws))).toThrow(
+      ImportTooLargeError,
+    );
+  });
+
+  it('allows a workbook exactly at the cell limit', () => {
+    expect(() => enforceImportLimit(MAX_IMPORT_CELLS)).not.toThrow();
+    expect(countWorksheetCells({ '!ref': 'A1:A1', A1: { t: 'n', v: 1 } })).toBe(1);
   });
 
   it('skips cells whose cellToCommand returns null (e.g. error cells)', () => {


### PR DESCRIPTION
Acts on the 2026-06-11 security report, scoped to the hosted
ethercalc.net (Cloudflare) surface. The room-enumeration findings
(H-1/M-4) are already gated there because wrangler.toml pins
ETHERCALC_CORS=1, so those remain self-host concerns and are out of
scope here. The remaining hosted-relevant, non-behaviour-changing fixes:

- M-8 email header/body injection: strip CR/LF/control bytes from the
  attacker-controllable `to`/`subject` cell values in parseSendemail and
  defensively in buildMimeEnvelope, so a sendemail payload can't fold or
  smuggle extra MIME headers through the send_email binding.
- M-6 CSV formula injection: neutralize formula/DDE-trigger leading
  characters (= + - @ tab CR) in the `.csv` download, exempting genuine
  numbers so ordinary data is untouched. csv.json stays faithful.
- H-5 HTML export stored XSS: serve the HTML export with a CSP
  (default-src 'none'; style-src 'unsafe-inline') that neutralizes
  injected <script>/onerror while keeping the table viewable and
  embeddable, plus X-Content-Type-Options: nosniff on all exports.
- M-9 xlsx/ods import DoS: cap the per-cell SocialCalc replay at
  MAX_IMPORT_CELLS before the loop, so a zip-bombed workbook can't pin
  the worker isolate.

Gated packages stay at 100% line/branch/function/statement coverage
(668 node tests); 145 workers-pool integration tests pass.

https://claude.ai/code/session_01Fd3hMfRjjiXkdeTaCnHBDd