### PR TITLE
fix(worker): retryable 503 on import-append DO version skew

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -14,6 +14,9 @@ Unreleased
 ==============================================================================
 
 Security
+- Multi-sheet append import maps a mixed-version RoomDO `501` on
+  `/_do/import-append-toc` to a retryable `503` with clear copy (Worker/DO
+  skew during deploy), instead of surfacing bare "Not implemented".
 - Closed stored DOM-XSS and cross-origin `postMessage` seams in graph and
   multi-sheet clients; HTML exports now use the same element, attribute, URL,
   and CSS-fetch allowlist as the live editor.

--- a/docs/migration/PROD_UPGRADE_PLAN.md
+++ b/docs/migration/PROD_UPGRADE_PLAN.md
@@ -1191,7 +1191,32 @@ curl -fsS -H "$HDR" -o /dev/null -w '%{http_code}\n' \
 
 Optional but strongly recommended under override before ramp (**`[OPERATOR-VERIFY]`**, throwaway/operator-owned private room + test passkey — no customer data): discoverable login; owner private R/W; anonymous private 403; over-limit `POST /_/:room` → **413**.
 
+#### Step 3c — DO-protocol additions: atomic 100% only (no gradual split)
+
+Cloudflare gradual deployments pin **each Durable Object instance to one Worker version** for the life of that deployment, while the front-door Worker isolate that handles an ingress request may be a *different* version ([Gradual deployments with Durable Objects](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/with-durable-objects/)). EtherCalc has **one `RoomDO` per room**, so a 10% / 50% ramp means some rooms still run the pre-ship DO class.
+
+**Rule:** introducing a **new `/_do/*` RoomDO endpoint** means the change **cannot be gradually ramped**. During any split (or a version-override that only selects the Worker entrypoint), requests routed to the new Worker may hit an old DO isolate and fail at the unknown-path catch-all (`501 Not implemented`, `packages/worker/src/room.ts`).
+
+- Deploy DO-protocol additions as an **atomic `versions deploy <SHIP>@100%` cutover** (skip Step 4’s 10/50 split).
+- Expect a **brief post-cutover window** until already-running RoomDO isolates reload onto ship code; the Worker MUST map that window to a **retryable** client error rather than a bare 501 (see `IMPORT_APPEND_DO_SKEW_MESSAGE` / `503` in `packages/worker/src/routes/multi-import.ts` for `POST /_do/import-append-toc`).
+- Sibling case already documented for passkey rollout: `POST /_do/init-private` against a Phase-1 DO returns 501 verbatim (Appendix A.1.3.1 / old §4.3.1).
+
+**Incident evidence (2026-08-11, issue #843 append import ship):**
+
+| Item | Value |
+| :--- | :---- |
+| Floor (rollback) | `0e024a32-5ce8-4315-a4eb-a4c5c2a8f780` @100% after abort |
+| Ship (aborted) | `1369531f-7366-4353-b8f0-a71cabb07c25` |
+| Split sampled | floor@90% / ship@10% |
+| Append sample n=80 (`POST /_/=<room>/csv`) | `{404: 66, 501: 12, 201: 2}` — real user-path 501s under split |
+| Asset discriminator (busted hash) | ~10% 200 / ~90% 404 (Worker selection worked) |
+| Override-only append | also `501 Not implemented` (Worker ship + DO still floor) |
+
+This is evidence, not folklore: **do not re-introduce a gradual split for this class of change.**
+
 #### Step 4 — Gradual ramp
+
+> **Skip this step** when the ship bundle adds or renames any `/_do/*` DO RPC (Step 3c). Go straight to `<SHIP>@100%`.
 
 ```bash
 vp exec wrangler versions deploy \

--- a/packages/worker/src/routes/multi-import.ts
+++ b/packages/worker/src/routes/multi-import.ts
@@ -51,6 +51,10 @@ import {
 const TEXT_CT = 'text/plain; charset=utf-8';
 const PRIVATE_IMPORT_MESSAGE =
   'Multi-sheet import is unavailable for private rooms because new sub-sheets would be public.';
+/** Returned when the parent RoomDO lacks `/_do/import-append-toc` (old isolate). */
+export const IMPORT_APPEND_DO_SKEW_MESSAGE =
+  'Import is briefly unavailable while the server finishes updating. Please retry in a moment.';
+
 
 /**
  * Mirror a DO 401/403 auth verdict to the client verbatim (status +
@@ -254,6 +258,18 @@ async function appendWorkbook(
     return new Response(await allocRes.text(), {
       status: 413,
       headers: { 'Content-Type': TEXT_CT },
+    });
+  }
+  // Old RoomDO isolates answer unknown /_do/* with bare 501. During a Worker/DO
+  // version skew window that must not surface as "Not implemented" — map it to a
+  // retryable 503 with operator-facing copy the multi client already alerts.
+  if (allocRes.status === 501) {
+    return new Response(IMPORT_APPEND_DO_SKEW_MESSAGE, {
+      status: 503,
+      headers: {
+        'Content-Type': TEXT_CT,
+        'Retry-After': '5',
+      },
     });
   }
   if (allocRes.status >= 300) {

--- a/packages/worker/test/multi-import.test.ts
+++ b/packages/worker/test/multi-import.test.ts
@@ -334,6 +334,64 @@ describe('POST multi-sheet append import', () => {
     expect(values.has('concurrent-B')).toBe(true);
   });
 
+  it('maps old RoomDO 501 on import-append-toc to retryable 503 with clear body', async () => {
+    // Mixed-version window: new Worker entrypoint + old RoomDO isolate that
+    // lacks /_do/import-append-toc returns bare 501 from the DO catch-all.
+    // Must not pass "Not implemented" through to the user.
+    const room = `mskew-${Math.random().toString(36).slice(2, 8)}`;
+    const seed = await request('PUT', `/=${room}.xlsx`, twoSheetXlsx());
+    expect(seed.status).toBe(201);
+
+    const realRoom = (env as unknown as Env).ROOM;
+    let sawAppendToc = false;
+    const skewEnv = {
+      ...(env as unknown as Env),
+      ROOM: {
+        idFromName: (name: string) => realRoom.idFromName(name),
+        idFromString: (id: string) =>
+          (realRoom as unknown as { idFromString(id: string): DurableObjectId }).idFromString(id),
+        get: (id: DurableObjectId) => {
+          const stub = realRoom.get(id);
+          return {
+            fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+              const url =
+                typeof input === 'string'
+                  ? input
+                  : input instanceof URL
+                    ? input.toString()
+                    : input.url;
+              if (url.includes('/_do/import-append-toc')) {
+                sawAppendToc = true;
+                return new Response('Not implemented', { status: 501 });
+              }
+              return stub.fetch(input as Request, init);
+            },
+          } as unknown as DurableObjectStub;
+        },
+      } as unknown as DurableObjectNamespace,
+    } as Env;
+
+    const csv = new TextEncoder().encode('A,B\n1,2\n');
+    const res = await requestWithEnv(skewEnv, 'POST', `/_/=${room}/csv`, csv);
+    expect(sawAppendToc).toBe(true);
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Retry-After')).toBe('5');
+    expect(res.headers.get('Content-Type') ?? '').toMatch(/text\/plain/);
+    const body = await res.text();
+    expect(body).toContain('briefly unavailable');
+    expect(body).toContain('retry');
+    expect(body.toLowerCase()).not.toContain('not implemented');
+
+    // No third child was minted; TOC still only the two seeded sheets.
+    const ghost = await request('GET', `/_/${room}.3`);
+    expect(ghost.status).toBe(404);
+    const toc = (await (await request('GET', `/_/${room}/csv.json`)).json()) as string[][];
+    expect(toc).toHaveLength(3);
+    expect(toc[0]).toEqual(['#url', '#title']);
+    expect(toc[1]).toEqual([`/${room}.1`, 'First']);
+    expect(toc[2]).toEqual([`/${room}.2`, 'Second']);
+  });
+
   it('rejects append and replace on private multi-sheet rooms for every format', async () => {
     const base = `mpriv-${Math.random().toString(36).slice(2, 8)}`;
     const initRes = await doFetch(


### PR DESCRIPTION
## Summary

Follow-up to the aborted #847 production ramp at 10%.

When the new Worker calls `POST /_do/import-append-toc` on a RoomDO isolate still running pre-ship code, the DO catch-all returns bare **`501 Not implemented`**. That is a real Worker↔DO skew window (also documented for `init-private` in the runbook appendix).

### Code
- Map **only** `import-append-toc` DO **501** → client **`503`** with `Retry-After: 5` and:
  > Import is briefly unavailable while the server finishes updating. Please retry in a moment.
- `packages/client-multi` already alerts `Import failed (status): body`.
- Workers-pool test: mocked DO 501 → 503 body, no child minted.

### Runbook
- New **§4.3 Step 3c**: new `/_do/*` RPCs cannot be gradually ramped; atomic `SHIP@100%` only; cite incident IDs `FLOOR 0e024a32` / `SHIP 1369531f` and sample `{404:66, 501:12, 201:2}`.

### Deploy intent
Atomic 100% cutover after local green (no 10/50 split).